### PR TITLE
Migrate from rustls to openssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,18 +11,21 @@ keywords = ["LND", "rpc", "grpc", "tonic", "async"]
 categories = ["api-bindings", "asynchronous", "cryptography::cryptocurrencies", "network-programming"]
 license = "MITNFA"
 
+[lib]
+doctest = false
+
 [dependencies]
-tonic = { version = "0.6.2", features = ["transport", "tls"] }
-prost = "0.9.0"
-rustls = { version = "0.19.0", features = ["dangerous_configuration"] }
-webpki = "0.21.3"
-rustls-pemfile = "1.0.0"
+tonic = "0.7"
+tonic-openssl = { version = "0.2" }
+hyper = "0.14"
+hyper-openssl = "0.9"
+prost = "0.10"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["net"] }
+openssl = "0.10"
+tower = "0.4"
+pretty_env_logger = "*"
 hex = "0.4.3"
-tokio = { version = "1.7.1", features = ["fs"] }
-tracing = { version = "0.1", features = ["log"], optional = true }
 
 [build-dependencies]
-tonic-build = "0.5.2"
-
-[dev-dependencies]
-tokio = { version = "1.7.1", features = ["rt-multi-thread"] }
+tonic-build = "0.7"

--- a/build.rs
+++ b/build.rs
@@ -31,7 +31,6 @@ fn main() -> std::io::Result<()> {
     tonic_build::configure()
         .build_client(true)
         .build_server(false)
-        .format(false)
         .compile(&proto_paths, &[dir])?;
     Ok(())
 }

--- a/examples/getinfo.rs
+++ b/examples/getinfo.rs
@@ -10,22 +10,24 @@ async fn main() {
     args.next().expect("not even zeroth arg given");
     let host = args
         .next()
-        .expect("missing arguments: host, port, cert file, macaroon file");
-    let port = args
+        .expect("missing arguments: host, port, cert file, macaroon file")
+        .into_string()
+        .expect("host is not UTF-8");
+    let port: u32 = args
         .next()
-        .expect("missing arguments: port, cert file, macaroon file");
-    let cert_file = args
-        .next()
-        .expect("missing arguments: cert file, macaroon file");
-    let macaroon_file = args.next().expect("missing argument: macaroon file");
-    let host: String = host.into_string().expect("host is not UTF-8");
-    let port: u32 = port
+        .expect("missing arguments: port, cert file, macaroon file")
         .into_string()
         .expect("port is not UTF-8")
         .parse()
         .expect("port is not u32");
-    let cert_file: String = cert_file.into_string().expect("cert_file is not UTF-8");
-    let macaroon_file: String = macaroon_file
+    let cert_file: String = args
+        .next()
+        .expect("missing arguments: cert file, macaroon file")
+        .into_string()
+        .expect("cert_file is not UTF-8");
+    let macaroon_file: String = args
+        .next()
+        .expect("missing argument: macaroon file")
         .into_string()
         .expect("macaroon_file is not UTF-8");
 

--- a/examples/getinfo.rs
+++ b/examples/getinfo.rs
@@ -8,13 +8,29 @@
 async fn main() {
     let mut args = std::env::args_os();
     args.next().expect("not even zeroth arg given");
-    let address = args.next().expect("missing arguments: address, cert file, macaroon file");
-    let cert_file = args.next().expect("missing arguments: cert file, macaroon file");
+    let host = args
+        .next()
+        .expect("missing arguments: host, port, cert file, macaroon file");
+    let port = args
+        .next()
+        .expect("missing arguments: port, cert file, macaroon file");
+    let cert_file = args
+        .next()
+        .expect("missing arguments: cert file, macaroon file");
     let macaroon_file = args.next().expect("missing argument: macaroon file");
-    let address = address.into_string().expect("address is not UTF-8");
+    let host: String = host.into_string().expect("host is not UTF-8");
+    let port: u32 = port
+        .into_string()
+        .expect("port is not UTF-8")
+        .parse()
+        .expect("port is not u32");
+    let cert_file: String = cert_file.into_string().expect("cert_file is not UTF-8");
+    let macaroon_file: String = macaroon_file
+        .into_string()
+        .expect("macaroon_file is not UTF-8");
 
-    // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = tonic_lnd::connect(address, cert_file, macaroon_file)
+    // Connecting to LND requires only host, port, cert file, macaroon file
+    let mut client = tonic_lnd::connect(host, port, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 

--- a/examples/subscribe_invoices.rs
+++ b/examples/subscribe_invoices.rs
@@ -6,17 +6,31 @@
 async fn main() {
     let mut args = std::env::args_os();
     args.next().expect("not even zeroth arg given");
-    let address = args
+    let host = args
         .next()
-        .expect("missing arguments: address, cert file, macaroon file");
-    let cert_file = args
+        .expect("missing arguments: host, port, cert file, macaroon file")
+        .into_string()
+        .expect("host is not UTF-8");
+    let port: u32 = args
         .next()
-        .expect("missing arguments: cert file, macaroon file");
-    let macaroon_file = args.next().expect("missing argument: macaroon file");
-    let address = address.into_string().expect("address is not UTF-8");
+        .expect("missing arguments: port, cert file, macaroon file")
+        .into_string()
+        .expect("port is not UTF-8")
+        .parse()
+        .expect("port is not u32");
+    let cert_file: String = args
+        .next()
+        .expect("missing arguments: cert file, macaroon file")
+        .into_string()
+        .expect("cert_file is not UTF-8");
+    let macaroon_file: String = args
+        .next()
+        .expect("missing argument: macaroon file")
+        .into_string()
+        .expect("macaroon_file is not UTF-8");
 
     // Connecting to LND requires only address, cert file, and macaroon file
-    let mut client = tonic_lnd::connect(address, cert_file, macaroon_file)
+    let mut client = tonic_lnd::connect(host, port, cert_file, macaroon_file)
         .await
         .expect("failed to connect");
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -13,19 +13,16 @@ pub struct ConnectError {
 
 impl From<InternalConnectError> for ConnectError {
     fn from(value: InternalConnectError) -> Self {
-        ConnectError {
-            internal: value,
-        }
+        ConnectError { internal: value }
     }
 }
 
 #[derive(Debug)]
 pub(crate) enum InternalConnectError {
-    ReadFile { file: PathBuf, error: std::io::Error, },
-    ParseCert { file: PathBuf, error: std::io::Error, },
-    InvalidAddress { address: String, error: Box<dyn std::error::Error + Send + Sync + 'static>, },
-    TlsConfig(tonic::transport::Error),
-    Connect { address: String, error: tonic::transport::Error, }
+    ReadFile {
+        file: PathBuf,
+        error: std::io::Error,
+    },
 }
 
 impl fmt::Display for ConnectError {
@@ -34,10 +31,6 @@ impl fmt::Display for ConnectError {
 
         match &self.internal {
             ReadFile { file, .. } => write!(f, "failed to read file {}", file.display()),
-            ParseCert { file, .. } => write!(f, "failed to parse certificate {}", file.display()),
-            InvalidAddress { address, .. } => write!(f, "invalid address {}", address),
-            TlsConfig(_) => write!(f, "failed to configure TLS"),
-            Connect { address, .. } => write!(f, "failed to connect to {}", address),
         }
     }
 }
@@ -48,10 +41,6 @@ impl std::error::Error for ConnectError {
 
         match &self.internal {
             ReadFile { error, .. } => Some(error),
-            ParseCert { error, .. } => Some(error),
-            InvalidAddress { error, .. } => Some(&**error),
-            TlsConfig(error) => Some(error),
-            Connect { error, .. } => Some(error),
         }
     }
 }


### PR DESCRIPTION
In the interest of moving forward with the proposals on PR #20 , this PR cherry picks migration from [rustls](https://crates.io/crates/rustls) to [openssl](https://crates.io/crates/openssl) for the TLS certificate handling, introduced by @yzernik because of https://github.com/Kixunil/tonic_lnd/issues/17.

closes #17 