### PR TITLE
Optional Lightning RPC under feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["LND", "rpc", "grpc", "tonic", "async"]
 categories = ["api-bindings", "asynchronous", "cryptography::cryptocurrencies", "network-programming"]
 license = "MITNFA"
 
+[features]
+lightningrpc = []
+all = ["lightningrpc"]
+
 [dependencies]
 tonic = { version = "0.6.2", features = ["transport", "tls"] }
 prost = "0.9.0"

--- a/examples/getinfo.rs
+++ b/examples/getinfo.rs
@@ -1,15 +1,20 @@
 // This example only fetches and prints the node info to the standard output similarly to
 // `lncli getinfo`.
 //
-// This program accepts three arguments: address, cert file, macaroon file
-// The address must start with `https://`!
+// The program accepts three arguments: address, cert file, macaroon file
+// Example run: `cargo run --features=lightningrpc --example getinfo <address> <tls.cert> <file.macaroon>`
 
 #[tokio::main]
+#[cfg(feature = "lightningrpc")]
 async fn main() {
     let mut args = std::env::args_os();
     args.next().expect("not even zeroth arg given");
-    let address = args.next().expect("missing arguments: address, cert file, macaroon file");
-    let cert_file = args.next().expect("missing arguments: cert file, macaroon file");
+    let address = args
+        .next()
+        .expect("missing arguments: address, cert file, macaroon file");
+    let cert_file = args
+        .next()
+        .expect("missing arguments: cert file, macaroon file");
     let macaroon_file = args.next().expect("missing argument: macaroon file");
     let address = address.into_string().expect("address is not UTF-8");
 

--- a/examples/subscribe_invoices.rs
+++ b/examples/subscribe_invoices.rs
@@ -1,8 +1,10 @@
-// This program connects to LND and prints out all incoming invoices as they settle.
+// This example connects to LND and prints out all incoming invoices as they settle.
+//
 // The program accepts three arguments: address, cert file, macaroon file
-// The address must start with `https://`!
+// Example run: `cargo run --features=lightningrpc --example subscribe_invoices <address> <tls.cert> <file.macaroon>`
 
 #[tokio::main]
+#[cfg(feature = "lightningrpc")]
 async fn main() {
     let mut args = std::env::args_os();
     args.next().expect("not even zeroth arg given");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ use tonic::transport::Channel;
 use tracing;
 
 /// Convenience type alias for lightning client.
+#[cfg(feature = "lightningrpc")]
 pub type LightningClient = lnrpc::lightning_client::LightningClient<InterceptedService<Channel, MacaroonInterceptor>>;
 
 /// Convenience type alias for wallet client.
@@ -98,6 +99,7 @@ pub type SignerClient = signrpc::signer_client::SignerClient<InterceptedService<
 ///
 /// This is a convenience type which you most likely want to use instead of raw client.
 pub struct Client {
+    #[cfg(feature = "lightningrpc")]
     lightning: LightningClient,
     wallet: WalletKitClient,
     signer: SignerClient,
@@ -106,6 +108,7 @@ pub struct Client {
 
 impl Client {
     /// Returns the lightning client.
+    #[cfg(feature = "lightningrpc")]
     pub fn lightning(&mut self) -> &mut LightningClient {
         &mut self.lightning
     }
@@ -144,6 +147,7 @@ macro_rules! try_map_err {
 ///
 /// This is the go-to module you will need to look in to find documentation on various message
 /// types. However it may be better to start from methods on the [`LightningClient`](lnrpc::lightning_client::LightningClient) type.
+#[cfg(feature = "lightningrpc")]
 pub mod lnrpc {
     tonic::include_proto!("lnrpc");
 }
@@ -209,6 +213,7 @@ pub async fn connect<A, CP, MP>(address: A, cert_file: CP, macaroon_file: MP) ->
     let interceptor = MacaroonInterceptor { macaroon, };
 
     let client = Client {
+        #[cfg(feature = "lightningrpc")]
         lightning: lnrpc::lightning_client::LightningClient::with_interceptor(conn.clone(), interceptor.clone()),
         wallet: walletrpc::wallet_kit_client::WalletKitClient::with_interceptor(conn.clone(), interceptor.clone()),
         peers: peersrpc::peers_client::PeersClient::with_interceptor(


### PR DESCRIPTION
1. Make Lightning RPC optionally available under `lightningrpc` feature gate.
  > Usage: `cargo run --features=lightningrpc --example getinfo <host> <port> <tls.cert> <file.macaroon>`

Partial fix to #26 