### PR TITLE
Optional Wallet RPC under feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ license = "MITNFA"
 
 [features]
 lightningrpc = []
-all = ["lightningrpc"]
+walletrpc = []
+all = ["lightningrpc", "walletrpc"]
 
 [dependencies]
 tonic = { version = "0.6.2", features = ["transport", "tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ keywords = ["LND", "rpc", "grpc", "tonic", "async"]
 categories = ["api-bindings", "asynchronous", "cryptography::cryptocurrencies", "network-programming"]
 license = "MITNFA"
 
+[features]
+lightningrpc = []
+all = ["lightningrpc"]
+
 [dependencies]
 tonic = { version = "0.6.2", features = ["transport", "tls"] }
 prost = "0.9.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,8 @@ license = "MITNFA"
 
 [features]
 lightningrpc = []
-walletrpc = []
+signrpc = []
+walletrpc = ["signrpc"]
 all = ["lightningrpc", "walletrpc"]
 
 [dependencies]

--- a/examples/getinfo.rs
+++ b/examples/getinfo.rs
@@ -1,15 +1,20 @@
 // This example only fetches and prints the node info to the standard output similarly to
 // `lncli getinfo`.
 //
-// This program accepts three arguments: address, cert file, macaroon file
-// The address must start with `https://`!
+// The program accepts three arguments: address, cert file, macaroon file
+// Example run: `cargo run --features=lightningrpc --example getinfo <address> <tls.cert> <file.macaroon>`
 
 #[tokio::main]
+#[cfg(feature = "lightningrpc")]
 async fn main() {
     let mut args = std::env::args_os();
     args.next().expect("not even zeroth arg given");
-    let address = args.next().expect("missing arguments: address, cert file, macaroon file");
-    let cert_file = args.next().expect("missing arguments: cert file, macaroon file");
+    let address = args
+        .next()
+        .expect("missing arguments: address, cert file, macaroon file");
+    let cert_file = args
+        .next()
+        .expect("missing arguments: cert file, macaroon file");
     let macaroon_file = args.next().expect("missing argument: macaroon file");
     let address = address.into_string().expect("address is not UTF-8");
 

--- a/examples/subscribe_invoices.rs
+++ b/examples/subscribe_invoices.rs
@@ -1,8 +1,10 @@
-// This program connects to LND and prints out all incoming invoices as they settle.
+// This example connects to LND and prints out all incoming invoices as they settle.
+//
 // The program accepts three arguments: address, cert file, macaroon file
-// The address must start with `https://`!
+// Example run: `cargo run --features=lightningrpc --example subscribe_invoices <address> <tls.cert> <file.macaroon>`
 
 #[tokio::main]
+#[cfg(feature = "lightningrpc")]
 async fn main() {
     let mut args = std::env::args_os();
     args.next().expect("not even zeroth arg given");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,7 @@ use std::convert::TryInto;
 pub use error::ConnectError;
 use error::InternalConnectError;
 use tonic::codegen::InterceptedService;
+#[allow(unused_imports)]
 use tonic::transport::Channel;
 
 #[cfg(feature = "tracing")]
@@ -84,9 +85,10 @@ use tracing;
 #[cfg(feature = "lightningrpc")]
 pub type LightningClient = lnrpc::lightning_client::LightningClient<InterceptedService<Channel, MacaroonInterceptor>>;
 
+
 /// Convenience type alias for wallet client.
-pub type WalletKitClient =
-    walletrpc::wallet_kit_client::WalletKitClient<InterceptedService<Channel, MacaroonInterceptor>>;
+#[cfg(feature = "walletrpc")]
+pub type WalletKitClient = walletrpc::wallet_kit_client::WalletKitClient<InterceptedService<Channel, MacaroonInterceptor>>;
 
 /// Convenience type alias for peers service client.
 pub type PeersClient =
@@ -101,6 +103,7 @@ pub type SignerClient = signrpc::signer_client::SignerClient<InterceptedService<
 pub struct Client {
     #[cfg(feature = "lightningrpc")]
     lightning: LightningClient,
+    #[cfg(feature = "walletrpc")]
     wallet: WalletKitClient,
     signer: SignerClient,
     peers: PeersClient,
@@ -114,6 +117,7 @@ impl Client {
     }
 
     /// Returns the wallet client.
+    #[cfg(feature = "walletrpc")]
     pub fn wallet(&mut self) -> &mut WalletKitClient {
         &mut self.wallet
     }
@@ -152,6 +156,7 @@ pub mod lnrpc {
     tonic::include_proto!("lnrpc");
 }
 
+#[cfg(feature = "walletrpc")]
 pub mod walletrpc {
     tonic::include_proto!("walletrpc");
 }
@@ -200,6 +205,7 @@ async fn load_macaroon(path: impl AsRef<Path> + Into<PathBuf>) -> Result<String,
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "Connecting to LND"))]
 pub async fn connect<A, CP, MP>(address: A, cert_file: CP, macaroon_file: MP) -> Result<Client, ConnectError> where A: TryInto<tonic::transport::Endpoint> + std::fmt::Debug + ToString, <A as TryInto<tonic::transport::Endpoint>>::Error: std::error::Error + Send + Sync + 'static, CP: AsRef<Path> + Into<PathBuf> + std::fmt::Debug, MP: AsRef<Path> + Into<PathBuf> + std::fmt::Debug {
     let address_str = address.to_string();
+    #[allow(unused_variables)]
     let conn = try_map_err!(address
         .try_into(), |error| InternalConnectError::InvalidAddress { address: address_str.clone(), error: Box::new(error), })
         .tls_config(tls::config(cert_file).await?)
@@ -210,12 +216,14 @@ pub async fn connect<A, CP, MP>(address: A, cert_file: CP, macaroon_file: MP) ->
 
     let macaroon = load_macaroon(macaroon_file).await?;
 
+    #[allow(unused_variables)]
     let interceptor = MacaroonInterceptor { macaroon, };
 
     let client = Client {
         #[cfg(feature = "lightningrpc")]
         lightning: lnrpc::lightning_client::LightningClient::with_interceptor(conn.clone(), interceptor.clone()),
-        wallet: walletrpc::wallet_kit_client::WalletKitClient::with_interceptor(conn.clone(), interceptor.clone()),
+        #[cfg(feature = "walletrpc")]
+        wallet: walletrpc::wallet_kit_client::WalletKitClient::with_interceptor(conn, interceptor),
         peers: peersrpc::peers_client::PeersClient::with_interceptor(
             conn.clone(),
             interceptor.clone(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ use tonic::transport::Channel;
 use tracing;
 
 /// Convenience type alias for lightning client.
+#[cfg(feature = "lightningrpc")]
 pub type LightningClient = lnrpc::lightning_client::LightningClient<InterceptedService<Channel, MacaroonInterceptor>>;
 
 /// Convenience type alias for wallet client.
@@ -98,6 +99,7 @@ pub type SignerClient = signrpc::signer_client::SignerClient<InterceptedService<
 ///
 /// This is a convenience type which you most likely want to use instead of raw client.
 pub struct Client {
+    #[cfg(feature = "lightningrpc")]
     lightning: LightningClient,
     wallet: WalletKitClient,
     signer: SignerClient,
@@ -106,6 +108,7 @@ pub struct Client {
 
 impl Client {
     /// Returns the lightning client.
+    #[cfg(feature = "lightningrpc")]
     pub fn lightning(&mut self) -> &mut LightningClient {
         &mut self.lightning
     }
@@ -144,6 +147,7 @@ macro_rules! try_map_err {
 ///
 /// This is the go-to module you will need to look in to find documentation on various message
 /// types. However it may be better to start from methods on the [`LightningClient`](lnrpc::lightning_client::LightningClient) type.
+#[cfg(feature = "lightningrpc")]
 pub mod lnrpc {
     tonic::include_proto!("lnrpc");
 }
@@ -209,6 +213,7 @@ pub async fn connect<A, CP, MP>(address: A, cert_file: CP, macaroon_file: MP) ->
     let interceptor = MacaroonInterceptor { macaroon, };
 
     let client = Client {
+        #[cfg(feature = "lightningrpc")]
         lightning: lnrpc::lightning_client::LightningClient::with_interceptor(conn.clone(), interceptor.clone()),
         wallet: walletrpc::wallet_kit_client::WalletKitClient::with_interceptor(conn.clone(), interceptor.clone()),
         peers: peersrpc::peers_client::PeersClient::with_interceptor(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ pub type PeersClient =
     peersrpc::peers_client::PeersClient<InterceptedService<Channel, MacaroonInterceptor>>;
 
 // Convenience type alias for signer client.
+#[cfg(feature = "signrpc")]
 pub type SignerClient = signrpc::signer_client::SignerClient<InterceptedService<Channel, MacaroonInterceptor>>;
 
 /// The client returned by `connect` function
@@ -105,6 +106,7 @@ pub struct Client {
     lightning: LightningClient,
     #[cfg(feature = "walletrpc")]
     wallet: WalletKitClient,
+    #[cfg(feature = "signrpc")]
     signer: SignerClient,
     peers: PeersClient,
 }
@@ -123,6 +125,7 @@ impl Client {
     }
 
     /// Returns the signer client.
+    #[cfg(feature = "signrpc")]
     pub fn signer(&mut self) -> &mut SignerClient {
         &mut self.signer
     }
@@ -161,6 +164,7 @@ pub mod walletrpc {
     tonic::include_proto!("walletrpc");
 }
 
+#[cfg(feature = "signrpc")]
 pub mod signrpc {
     tonic::include_proto!("signrpc");
 }
@@ -228,6 +232,7 @@ pub async fn connect<A, CP, MP>(address: A, cert_file: CP, macaroon_file: MP) ->
             conn.clone(),
             interceptor.clone(),
         ),
+        #[cfg(feature = "signrpc")]
         signer: signrpc::signer_client::SignerClient::with_interceptor(conn, interceptor),
     };
     Ok(client)


### PR DESCRIPTION
Make Wallet RPC optionally available under `walletrpc` feature gate.

Usage: `cargo run --features=walletrpc --example <example> <host> <port> <tls.cert> <file.macaroon>`

Partial fix to #26 
Merge after #27 