### PR TITLE
In memory creds

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ mod tls {
         pub(crate) async fn load(path: impl AsRef<Path> + Into<PathBuf>) -> Result<Self, InternalConnectError> {
             let contents = try_map_err!(tokio::fs::read(&path).await,
                 |error| InternalConnectError::ReadFile { file: path.into(), error });
-                Ok(CertVerifier::do_load(&contents[..]).await?)
+            Ok(CertVerifier::do_load(&contents[..]).await?)
         }
         pub(crate) async fn load_from_memory(cert_pem: &str) -> Result<Self, InternalConnectError> {
             Ok(CertVerifier::do_load(&cert_pem.as_bytes()[..]).await?)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,11 +159,8 @@ async fn load_macaroon(path: impl AsRef<Path> + Into<PathBuf>) -> Result<String,
 /// don't have to. The address must begin with "https://", though.
 ///
 /// This is considered the recommended way to connect to LND. An alternative function to use
-/// already-read certificate or macaroon data is currently **not** provided to discourage such use.
+/// already-read certificate or macaroon data is provided at unreliable_connect_from_memory, but not recommended.
 /// LND occasionally changes that data which would lead to errors and in turn in worse application.
-///
-/// If you have a motivating use case for use of direct data feel free to open an issue and
-/// explain.
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "Connecting to LND"))]
 pub async fn connect<A, CP, MP>(address: A, cert_file: CP, macaroon_file: MP) -> Result<Client, ConnectError> where A: TryInto<tonic::transport::Endpoint> + std::fmt::Debug + ToString, <A as TryInto<tonic::transport::Endpoint>>::Error: std::error::Error + Send + Sync + 'static, CP: AsRef<Path> + Into<PathBuf> + std::fmt::Debug, MP: AsRef<Path> + Into<PathBuf> + std::fmt::Debug {
     let tls_config = tls::config(cert_file).await?;
@@ -174,8 +171,10 @@ pub async fn connect<A, CP, MP>(address: A, cert_file: CP, macaroon_file: MP) ->
 /// Connects to LND using in-memory cert and macaroon (not file paths)
 /// cert is a PEM encoded string
 /// macaroon is a hex-encoded string
+/// These credentials can get out of date! Make sure you are pulling fresh
+/// credentials when using this function.
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "Connecting to LND"))]
-pub async fn connect_from_memory<A>(address: A, cert_pem: &str, macaroon: &str) -> Result<Client, ConnectError> where A: TryInto<tonic::transport::Endpoint> + std::fmt::Debug + ToString, <A as TryInto<tonic::transport::Endpoint>>::Error: std::error::Error + Send + Sync + 'static {
+pub async fn unreliable_connect_from_memory<A>(address: A, cert_pem: &str, macaroon: &str) -> Result<Client, ConnectError> where A: TryInto<tonic::transport::Endpoint> + std::fmt::Debug + ToString, <A as TryInto<tonic::transport::Endpoint>>::Error: std::error::Error + Send + Sync + 'static {
     let tls_config = tls::config_from_memory(cert_pem).await?;
     Ok(do_connect(address, tls_config, macaroon).await?)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,7 +190,7 @@ pub async fn connect<A, CP, MP>(address: A, cert_file: CP, macaroon_file: MP) ->
 /// cert is a PEM encoded string
 /// macaroon is a hex-encoded string
 #[cfg_attr(feature = "tracing", tracing::instrument(name = "Connecting to LND"))]
-pub async fn connect_from_memory<A, CP, MP>(address: A, cert_pem: &str, macaroon: &str) -> Result<Client, ConnectError> where A: TryInto<tonic::transport::Endpoint> + std::fmt::Debug + ToString, <A as TryInto<tonic::transport::Endpoint>>::Error: std::error::Error + Send + Sync + 'static {
+pub async fn connect_from_memory<A>(address: A, cert_pem: &str, macaroon: &str) -> Result<Client, ConnectError> where A: TryInto<tonic::transport::Endpoint> + std::fmt::Debug + ToString, <A as TryInto<tonic::transport::Endpoint>>::Error: std::error::Error + Send + Sync + 'static {
     let address_str = address.to_string();
     let conn = try_map_err!(address
         .try_into(), |error| InternalConnectError::InvalidAddress { address: address_str.clone(), error: Box::new(error), })


### PR DESCRIPTION
This branch has an added `connect_from_memory` function, that allows connecting with cert and macaroon data from memory (instead of a filepath). Useful for docker deployments etc. Tested and working.

Not sure if anyone else needs this! Or if there is a cleaner way to add this functionality