### PR TITLE
Surface signer api in client

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Rust implementation of LND RPC client using async gRPC library `tonic`.
 **Warning: this crate is in early development and may have unknown problems!
 Review it before using with mainnet funds!**
 
-This crate supports *[Lightning](https://api.lightning.community/#service-lightning)* and *[WalletKit](https://api.lightning.community/#service-walletkit)* RPC APIs from LND [v0.15.4-beta](https://github.com/lightningnetwork/lnd/tree/v0.15.4-beta)
+This crate supports *[Lightning](https://api.lightning.community/#service-lightning)*,  *[WalletKit](https://api.lightning.community/#service-walletkit)* and *[Signer](https://lightning.engineering/api-docs/category/signer-service)* RPC APIs from LND [v0.15.4-beta](https://github.com/lightningnetwork/lnd/tree/v0.15.4-beta)
 
 This crate implements LND GRPC using [`tonic`](https://docs.rs/tonic/) and [`prost`](https://docs.rs/prost/).
 Apart from being up-to-date at the time of writing (:D) it also allows `async` usage.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,12 +81,16 @@ pub type LightningClient = lnrpc::lightning_client::LightningClient<InterceptedS
 /// Convenience type alias for wallet client.
 pub type WalletKitClient = walletrpc::wallet_kit_client::WalletKitClient<InterceptedService<Channel, MacaroonInterceptor>>;
 
+// Convenience type alias for signer client.
+pub type SignerClient = signrpc::signer_client::SignerClient<InterceptedService<Channel, MacaroonInterceptor>>;
+
 /// The client returned by `connect` function
 ///
 /// This is a convenience type which you most likely want to use instead of raw client.
 pub struct Client {
     lightning: LightningClient,
     wallet: WalletKitClient,
+    signer: SignerClient,
 }
 
 impl Client {
@@ -98,6 +102,11 @@ impl Client {
     /// Returns the wallet client.
     pub fn wallet(&mut self) -> &mut WalletKitClient {
         &mut self.wallet
+    }
+
+    /// Returns the signer client.
+    pub fn signer(&mut self) -> &mut SignerClient {
+        &mut self.signer
     }
 }
 
@@ -181,7 +190,8 @@ pub async fn connect<A, CP, MP>(address: A, cert_file: CP, macaroon_file: MP) ->
 
     let client = Client {
         lightning: lnrpc::lightning_client::LightningClient::with_interceptor(conn.clone(), interceptor.clone()),
-        wallet: walletrpc::wallet_kit_client::WalletKitClient::with_interceptor(conn, interceptor)
+        wallet: walletrpc::wallet_kit_client::WalletKitClient::with_interceptor(conn.clone(), interceptor.clone()),
+        signer: signrpc::signer_client::SignerClient::with_interceptor(conn, interceptor)
     };
     Ok(client)
 }


### PR DESCRIPTION
This PR surfaces the `SignerClient` in the same manner as `Lightning` and `Wallet`. 
