### PR TITLE
Enable clone trait for convenience client type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,7 @@ pub type SignerClient = signrpc::signer_client::SignerClient<InterceptedService<
 /// The client returned by `connect` function
 ///
 /// This is a convenience type which you most likely want to use instead of raw client.
+#[derive(Clone)]
 pub struct Client {
     lightning: LightningClient,
     wallet: WalletKitClient,


### PR DESCRIPTION
Just a small change to enable clone trait for the convenience client type. My understanding is cloning a grpc client is lightweight. We can clone each individual client (lightning, wallet, peers, etc), but this makes it possible to clone the whole tonic_lnd Client convenience type