### PR TITLE
Add support for versioner service

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,7 @@ fn main() -> std::io::Result<()> {
         "walletrpc/walletkit.proto",
         "lightning.proto",
         "peersrpc/peers.proto",
+        "verrpc/verrpc.proto",
     ];
 
     let proto_paths: Vec<_> = protos

--- a/examples/getversion.rs
+++ b/examples/getversion.rs
@@ -1,0 +1,23 @@
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args_os();
+    args.next().expect("not even zeroth arg given");
+    let address = args.next().expect("missing arguments: address, cert file, macaroon file");
+    let cert_file = args.next().expect("missing arguments: cert file, macaroon file");
+    let macaroon_file = args.next().expect("missing argument: macaroon file");
+    let address = address.into_string().expect("address is not UTF-8");
+
+    // Connecting to LND requires only address, cert file, and macaroon file
+    let mut client = tonic_lnd::connect(address, cert_file, macaroon_file)
+        .await
+        .expect("failed to connect");
+
+    let version = client
+        .versioner()
+        .get_version(tonic_lnd::verrpc::VersionRequest {})
+        .await
+        .expect("failed to get version");
+    // We only print it here, note that in real-life code you may want to call `.into_inner()` on
+    // the response to get the message.
+    println!("{:#?}", version);
+}

--- a/vendor/verrpc/verrpc.proto
+++ b/vendor/verrpc/verrpc.proto
@@ -1,0 +1,47 @@
+syntax = "proto3";
+
+package verrpc;
+
+option go_package = "github.com/lightningnetwork/lnd/lnrpc/verrpc";
+
+// Versioner is a service that can be used to get information about the version
+// and build information of the running daemon.
+service Versioner {
+    /* lncli: `version`
+    GetVersion returns the current version and build information of the running
+    daemon.
+    */
+    rpc GetVersion (VersionRequest) returns (Version);
+}
+
+message VersionRequest {
+}
+
+message Version {
+    // A verbose description of the daemon's commit.
+    string commit = 1;
+
+    // The SHA1 commit hash that the daemon is compiled with.
+    string commit_hash = 2;
+
+    // The semantic version.
+    string version = 3;
+
+    // The major application version.
+    uint32 app_major = 4;
+
+    // The minor application version.
+    uint32 app_minor = 5;
+
+    // The application patch number.
+    uint32 app_patch = 6;
+
+    // The application pre-release modifier, possibly empty.
+    string app_pre_release = 7;
+
+    // The list of build tags that were supplied during compilation.
+    repeated string build_tags = 8;
+
+    // The version of go that compiled the executable.
+    string go_version = 9;
+}


### PR DESCRIPTION
This adds support for the [versioner service](https://lightning.engineering/api-docs/category/versioner-service) . This will be useful for the [lndk project](https://github.com/carlaKC/lndk). Closes #38

I used https://github.com/Kixunil/tonic_lnd/pull/33 as a reference, since it makes much the same additions but for the peersrpc service.

Thanks much to anyone able to review