### PR TITLE
Conditionally use WebPKI trust anchors to validate certs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rustls-pemfile = "1.0.0"
 hex = "0.4.3"
 tokio = { version = "1.7.1", features = ["fs"] }
 tracing = { version = "0.1", features = ["log"], optional = true }
+webpki-roots = "0.19.0"
 
 [build-dependencies]
 tonic-build = "0.5.2"


### PR DESCRIPTION
This (finally) addresses #1 (and #24).

The interface of it is perhaps not ideal, but this is the actual logic that we need.  Optionally we could set a more explicit config value instead of passing a non-path.  I'd love feedback on that front.

The change is pretty trivial but it wound up being kind of a pain chasing through the relevant versions of (very old) rustls/webpki_roots to decide which versions will work elegantly together.